### PR TITLE
Specify the version of django

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,8 @@ FROM python:3.5
 # docker build -f DockerBasic/Dockerfile -t mxu/lepv0.1 .
 
 RUN apt-get update
-RUN apt-get -y install vim less
 
-RUN pip install django djangorestframework uwsgi
+RUN pip install django==1.10.8 djangorestframework==3.5.4 uwsgi==2.0.1
 
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code


### PR DESCRIPTION
after dropping docker image caches, we rebuild image, we will get server error 500.
this patch specify the versions of related software.
TODO: further fix and locate the root cause of server 500 using new django.

BTW, this patch also drops vim and less in dockerfile to shrink the image.

Signed-off-by: Barry Song <baohua@linuxep.com>